### PR TITLE
Increase Nexus resources request.

### DIFF
--- a/kubernetes/nexus-statefulset.yaml
+++ b/kubernetes/nexus-statefulset.yaml
@@ -15,10 +15,21 @@ spec:
       containers:
         - env:
             - name: INSTALL4J_ADD_VM_PARAMS
-              value: "-Xms1200m -Xmx1200m"
+              value: "-Xms1200M -Xmx1200M -XX:MaxDirectMemorySize=2G -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
           image: "quay.io/travelaudience/docker-nexus:3.4.0"
           imagePullPolicy: Always
           name: nexus
+          resources:
+            requests:
+              # Based on https://support.sonatype.com/hc/en-us/articles/115006448847#mem
+              # and https://twitter.com/analytically/status/894592422382063616:
+              #   Xms == Xmx
+              #   Xmx <= 4G
+              #   MaxDirectMemory >= 2G
+              #   Xmx + MaxDirectMemory <= RAM * 2/3 (hence the request for 4800Mi)
+              #   MaxRAMFraction=1 is not being set as it would allow the heap
+              #     to use all the available memory.
+              memory: 4800Mi
           ports:
             - containerPort: 5003
               name: nexus-docker-g

--- a/kubernetes/nexus-statefulset.yaml
+++ b/kubernetes/nexus-statefulset.yaml
@@ -21,6 +21,7 @@ spec:
           name: nexus
           resources:
             requests:
+              cpu: 250m
               # Based on https://support.sonatype.com/hc/en-us/articles/115006448847#mem
               # and https://twitter.com/analytically/status/894592422382063616:
               #   Xms == Xmx


### PR DESCRIPTION
Based on https://support.sonatype.com/hc/en-us/articles/115006448847#mem and https://twitter.com/analytically/status/894592422382063616:

* Xms == Xmx.
* Xmx <= 4G.
* MaxDirectMemory >= 2G.
* Xmx + MaxDirectMemory <= RAM * 2/3 (hence the request for `4800Mi`).

`MaxRAMFraction=1` is not being set as it would allow the heap use all the available memory.

I'm also setting the CPU resource request based on my testing so far.